### PR TITLE
Distortion map bug fix

### DIFF
--- a/src/terrainGenerator/meshGenerator.cpp
+++ b/src/terrainGenerator/meshGenerator.cpp
@@ -519,12 +519,12 @@ void updateTerrainMeshTexture(Mesh *terrainMesh, const NoiseMapData &noiseMapDat
                   generateColorMapTexture(noiseMap, colors, heights).data());
 }
 
-void updateTerrainMeshWaterTextures(Mesh *terrainMesh, const std::string mapIndex) {
+void updateTerrainMeshWaterTextures(Mesh *waterMesh, const std::string mapIndex) {
   int dudvWidth, dudvHeight;
   unsigned char *dudvPixelData = nullptr;
   loadTexture("waterDuDv" + mapIndex + ".png", waterDuDvTexturePath, &dudvWidth, &dudvHeight, &dudvPixelData);
   assert(dudvPixelData != nullptr);
-  createTexture2D(&terrainMesh->textureHandles[3], GL_REPEAT, GL_NEAREST, dudvWidth, dudvHeight,
+  createTexture2D(&waterMesh->textureHandles[0], GL_REPEAT, GL_LINEAR, dudvWidth, dudvHeight,
                   GL_UNSIGNED_BYTE, dudvPixelData);
   freeTexture(dudvPixelData);
 
@@ -533,7 +533,7 @@ void updateTerrainMeshWaterTextures(Mesh *terrainMesh, const std::string mapInde
   loadTexture("waterNormalMap" + mapIndex + ".png", waterNormalMapTexturePath, &normalMapWidth,
               &normalMapHeight, &normalMapPixelData);
   assert(normalMapPixelData != nullptr);
-  createTexture2D(&terrainMesh->textureHandles[4], GL_REPEAT, GL_NEAREST, normalMapWidth, normalMapHeight,
+  createTexture2D(&waterMesh->textureHandles[1], GL_REPEAT, GL_LINEAR, normalMapWidth, normalMapHeight,
                   GL_UNSIGNED_BYTE, normalMapPixelData);
   freeTexture(normalMapPixelData);
 }

--- a/src/terrainGenerator/sceneUI.cpp
+++ b/src/terrainGenerator/sceneUI.cpp
@@ -126,7 +126,7 @@ void handleUIInput(SceneSettings *sceneSettings, TerrainData *terrainData, Scene
       const auto isSelected = sceneSettings->currentWaterDuDv == sceneSettings->waterDuDvs[i];
       if (ImGui::Selectable(sceneSettings->waterDuDvs[i].c_str(), isSelected)) {
         sceneSettings->currentWaterDuDv = sceneSettings->waterDuDvs[i];
-        updateTerrainMeshWaterTextures(&meshIdToMesh->at(kTerrainMeshId), sceneSettings->currentWaterDuDv);
+        updateTerrainMeshWaterTextures(&meshIdToMesh->at(kWaterMeshId), sceneSettings->currentWaterDuDv);
       }
 
       if (isSelected)


### PR DESCRIPTION
Fixed so water mesh (instead of terrain mesh...) updates its textures when choosing a different distortion map.
Changed from nearest to linear interpolation when updating distortion map